### PR TITLE
Fixed HttpHeader to use NLog Layout for dynamic config lookup

### DIFF
--- a/NLog.Targets.Http/NHttpHeader.cs
+++ b/NLog.Targets.Http/NHttpHeader.cs
@@ -1,8 +1,12 @@
-﻿namespace NLog.Targets.Http
+﻿using NLog.Layouts;
+using NLog.Config;
+
+namespace NLog.Targets.Http
 {
+    [NLogConfigurationItem]
     public class NHttpHeader
     {
         public string Name { get; set; }
-        public string Value { get; set; }
+        public Layout Value { get; set; }
     }
 }


### PR DESCRIPTION
Now header values can be loaded for [app.config](https://github.com/NLog/NLog/wiki/AppSetting-Layout-Renderer) or [appsetting.json](https://github.com/NLog/NLog/wiki/ConfigSetting-Layout-Renderer) or [NLog GDC](https://github.com/NLog/NLog/wiki/gdc-Layout-Renderer).

Making it easier to have environment-neutral nlog-config, and retrieve environment specific values elsewhere.