### PR TITLE
Handle timeout as HTTP Error

### DIFF
--- a/NLog.Targets.Http/HTTP.cs
+++ b/NLog.Targets.Http/HTTP.cs
@@ -372,6 +372,25 @@ namespace NLog.Targets.Http
                 _hasHttpError = true;
                 return false;
             }
+#if NET5_0_OR_GREATER
+            catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+            {
+                _hasHttpError = true;
+                return false;
+            }
+#elif NETCOREAPP_OR_GREATER
+            catch (TaskCanceledException ex)
+            {
+                if (ex.Message.Contains("Timeout"))
+                {
+                    _hasHttpError = true;
+                    return false;
+                } else {
+                    InternalLogger.Warn(ex, "Unknown exception occured");
+                    return false;
+                }
+            }
+#endif
             catch (Exception ex)
             {
                 InternalLogger.Warn(ex, "Unknown exception occured");

--- a/NLog.Targets.Http/HTTP.cs
+++ b/NLog.Targets.Http/HTTP.cs
@@ -378,7 +378,7 @@ namespace NLog.Targets.Http
                 _hasHttpError = true;
                 return false;
             }
-#elif NETCOREAPP_OR_GREATER
+#elif NETCOREAPP3_1_OR_GREATER
             catch (TaskCanceledException ex)
             {
                 if (ex.Message.Contains("Timeout"))

--- a/NLog.Targets.Http/HTTP.cs
+++ b/NLog.Targets.Http/HTTP.cs
@@ -372,13 +372,11 @@ namespace NLog.Targets.Http
                 _hasHttpError = true;
                 return false;
             }
-#if NET5_0_OR_GREATER
             catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
             {
                 _hasHttpError = true;
                 return false;
             }
-#elif NETCOREAPP3_1_OR_GREATER
             catch (TaskCanceledException ex)
             {
                 if (ex.Message.Contains("Timeout"))
@@ -390,7 +388,6 @@ namespace NLog.Targets.Http
                     return false;
                 }
             }
-#endif
             catch (Exception ex)
             {
                 InternalLogger.Warn(ex, "Unknown exception occured");

--- a/NLog.Targets.Http/NLog.Targets.Http.csproj
+++ b/NLog.Targets.Http/NLog.Targets.Http.csproj
@@ -12,7 +12,7 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/DarekDan/NLog.Targets.HTTP</RepositoryUrl>
-    <Version>1.0.16</Version>
+    <Version>1.0.17-prerelease</Version>
     <PackageIcon>nlog-http.png</PackageIcon>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageReleaseNotes>Version 1.0.16


### PR DESCRIPTION
.NET Core's HttpClient throws a TaskCancelledException upon Timeout. This can be seen in the NLog Internal log:

```
2021-11-16 09:50:06.8575 Warn **Unknown exception occured** Exception: System.Threading.Tasks.**TaskCanceledException**: The request was canceled due to the configured **HttpClient.Timeout of 30 seconds elapsing**.
 ---> System.TimeoutException: A task was canceled.
 ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellationAsync(CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.GetHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.DiagnosticsHandler.SendAsyncCore(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   --- End of inner exception stack trace ---
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at NLog.Targets.Http.HTTP.SendFast(ArraySegment`1 message)
```

This change checks if there was a HTTP Timeout in NET5.0 and greater (Thanks https://stackoverflow.com/a/65989456/1317161), and checks if the exception contains the word "Timeout" in .NET Core 3.1 Versions.