### PR TITLE
Updated to AsyncTaskTarget with internal queue + batching + retry logic

### DIFF
--- a/NLog.Targets.Http/HTTP.cs
+++ b/NLog.Targets.Http/HTTP.cs
@@ -225,6 +225,17 @@ namespace NLog.Targets.Http
             HttpErrorRetryTimeout = 500;
         }
 
+
+        /// <inheritdoc />
+        protected override void CloseTarget()
+        {
+            var oldHttpClient = _httpClient;
+            NotifyPropertyChanged(nameof(Url)); // Ensure to create fresh HttpClient
+            _httpClient = null;
+            oldHttpClient?.Dispose();
+            base.CloseTarget();
+        }
+
         protected override Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken cancellationToken)
         {
             throw new NotSupportedException();  // Never called
@@ -336,6 +347,10 @@ namespace NLog.Targets.Http
 
             lock (_propertiesChanged)
             {
+                var oldHttpClient = _httpClient;
+                _httpClient = null;
+                oldHttpClient?.Dispose();
+
                 // ReSharper disable once UseObjectOrCollectionInitializer
 #if NETCOREAPP
                 var handler = new SocketsHttpHandler();

--- a/NLog.Targets.Http/NLog.Targets.Http.csproj
+++ b/NLog.Targets.Http/NLog.Targets.Http.csproj
@@ -102,7 +102,7 @@
 
   <!--common NuGet package refs -->
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.13" />
+    <PackageReference Include="NLog" Version="4.7.15" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
In respect of #44. Alternative to #45

Has the following side-effects: 
- Background-thread only runs when something to do, and becomes quiet when nothing to do.
- Application-thread no longer performs encoding to byte-arrays, but instead happens on the background-thread.
- Application-thread is only forced to help render payload when needing to capture thread-execution-state.
- Internal queue will keep NLog LogEventInfo-objects alive, instead of basic byte-arrays.
- HttpRequest errors that lead to retry will cause re-allocation of payload for every retry.
- Retry will not cause out-of-order processing, so if unable to handle single request then it will only retry that until timeout (Default after 150 secs and controlled by `TaskTimeoutSeconds` and also `RetryCount`)
- InMemoryCompression is now obsolete
- Enables correct support for [FallbackGroup](https://github.com/NLog/NLog/wiki/FallbackGroup-target) with redirect/failover of target-output on failure.